### PR TITLE
Bump the minor version instead of the major version

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,11 +21,9 @@ description:         Please see the README on GitHub at <https://github.com/psib
 
 dependencies:
 - base       >= 4.7 && < 5
-  # Should have an exact version match as we are depending on Internal modules.
-  # Currently compatable with streamly HEAD on GitHub.
-- streamly   >= 0.8.0  && < 0.9
-  # Keep the upper bound inclusive of the latest stable minor release of
-  # bytestring.
+  # Keep the upper bound inclusive of the latest stable minor release for
+  # packages depending on internal modules: streamly and bytestring
+- streamly   >= 0.8.0  && <= 0.8.0
 - bytestring >= 0.10.0 && <= 0.11.1.0
 
 when:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                streamly-bytestring
-version:             0.2.0
+version:             0.1.3
 github:              "psibi/streamly-bytestring"
 license:             BSD3
 author:              "Sibi Prabakaran"
@@ -24,7 +24,9 @@ dependencies:
   # Should have an exact version match as we are depending on Internal modules.
   # Currently compatable with streamly HEAD on GitHub.
 - streamly   >= 0.8.0  && < 0.9
-- bytestring >= 0.10.0 && < 0.11
+  # Keep the upper bound inclusive of the latest stable minor release of
+  # bytestring.
+- bytestring >= 0.10.0 && <= 0.11.1.0
 
 when:
   - condition: impl(ghc < 8.1)

--- a/streamly-bytestring.cabal
+++ b/streamly-bytestring.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1ef0ef3dbd9e28e62e9af0e872b34f6db96f5339d8824797d8a6a90d91382845
+-- hash: ec5d4099c0c82b1487393616056b1f4f77ac9bd91e3764f38fd227abf5fe6dfd
 
 name:           streamly-bytestring
 version:        0.1.3
@@ -39,7 +39,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring >=0.10.0 && <=0.11.1.0
-    , streamly >=0.8.0 && <0.9
+    , streamly >=0.8.0 && <=0.8.0
   if impl(ghc < 8.1)
     build-depends:
         base-compat >=0.11

--- a/streamly-bytestring.cabal
+++ b/streamly-bytestring.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0e0d7505dc4081ac70daf56ad1fe5c9fbe6386829c6462f45744c1fe26690768
+-- hash: 1ef0ef3dbd9e28e62e9af0e872b34f6db96f5339d8824797d8a6a90d91382845
 
 name:           streamly-bytestring
-version:        0.2.0
+version:        0.1.3
 synopsis:       Library for streamly and bytestring interoperation.
 description:    Please see the README on GitHub at <https://github.com/psibi/streamly-bytestring#readme>
 category:       Streamly, Stream, ByteString
@@ -38,8 +38,6 @@ library
   ghc-options: -Wall -O2
   build-depends:
       base >=4.7 && <5
-      -- Keep the upper bound inclusive of the latest stable minor release of
-      -- bytestring.
     , bytestring >=0.10.0 && <=0.11.1.0
     , streamly >=0.8.0 && <0.9
   if impl(ghc < 8.1)


### PR DESCRIPTION
There is no API change nor have any orphan instances been added.
According to the PVP, this only warrants a minor version release.

@jac3km4 