### PR TITLE
Relax upper bound on bytestring

### DIFF
--- a/streamly-bytestring.cabal
+++ b/streamly-bytestring.cabal
@@ -31,7 +31,7 @@ library
   ghc-options: -Wall -O2
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10.0 && <=0.11.3.0
+    , bytestring >=0.10.0 && <0.12
     , streamly == 0.8.1.* || == 0.8.2.*
   if impl(ghc < 8.1)
     build-depends:


### PR DESCRIPTION
bytestring-0.11.3.0 causes panics and other issues on windows.
the current constraint doesn't make sense from a PVP point of view
either.

* https://gitlab.haskell.org/ghc/ghc/-/issues/21179
* https://github.com/haskell/bytestring/pull/500
