### PR TITLE
Update streamly bounds

### DIFF
--- a/streamly-bytestring.cabal
+++ b/streamly-bytestring.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           streamly-bytestring
-version:        0.1.5
+version:        0.1.4
 synopsis:       Library for streamly and bytestring interoperation.
 description:    Please see the README on GitHub at <https://github.com/psibi/streamly-bytestring#readme>
 category:       Streamly, Stream, ByteString
@@ -32,7 +32,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring >=0.10.0 && <=0.11.3.1
-    , streamly >=0.8.1 && <0.9
+    , streamly == 0.8.1.* || == 0.8.2.* || == 0.8.3.*
   if impl(ghc < 8.1)
     build-depends:
         base-compat >=0.11

--- a/streamly-bytestring.cabal
+++ b/streamly-bytestring.cabal
@@ -1,6 +1,6 @@
 cabal-version:  1.12
 name:           streamly-bytestring
-version:        0.1.4
+version:        0.1.5
 synopsis:       Library for streamly and bytestring interoperation.
 description:    Please see the README on GitHub at <https://github.com/psibi/streamly-bytestring#readme>
 category:       Streamly, Stream, ByteString
@@ -32,7 +32,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring >=0.10.0 && <=0.11.3.1
-    , streamly == 0.8.1.* || == 0.8.2.*
+    , streamly >=0.8.1 && <0.9
   if impl(ghc < 8.1)
     build-depends:
         base-compat >=0.11


### PR DESCRIPTION
Streamly 0.8.2 cannot be used with GHC 9.4 since it rejects base 4.17.
This minor fix relaxes upper bounds for streamly, which in turns allows GHC 9.4.

Cheers :)